### PR TITLE
Added code for opt-in only telemetry

### DIFF
--- a/src/SettingsTheme.tsx
+++ b/src/SettingsTheme.tsx
@@ -195,6 +195,7 @@ class SettingsTheme extends ComponentEx<IProps, IComponentState> {
   }
 
   private onClone = () => {
+    this.context.api.events.emit('analytics-track-click-event', 'Themes', 'Clone theme');
     this.clone();
   }
 
@@ -299,6 +300,7 @@ class SettingsTheme extends ComponentEx<IProps, IComponentState> {
   }
 
   private selectTheme = (evt) => {
+    this.context.api.events.emit('analytics-track-click-event', 'Themes', 'Select theme');
     this.selectThemeImpl(evt.currentTarget.value);
   }
 


### PR DESCRIPTION
This MR adds the code required for collecting telemetry in Vortex. This is going to be a totally optional opt-in system for users that want to help improve Vortex by providing us with anonymous usage data.